### PR TITLE
Changed api to use builtin python types instead of JSON

### DIFF
--- a/identifiers_client/helpers.py
+++ b/identifiers_client/helpers.py
@@ -1,3 +1,4 @@
+import json
 # Pattern (and code) taken from:
 # https://gist.github.com/mivade/384c2c41c3a29c637cb6c603d4197f9f
 
@@ -37,3 +38,17 @@ def clear_internal_args(args):
         except KeyError:
             pass  # Its ok if the key is not in the list to be cleared
     return args
+
+
+def json_parse_args(in_dict, key_names):
+    for key_name in key_names:
+        val = in_dict.pop(key_name, None)
+        if val is not None:
+            try:
+                val = json.loads(val)
+            except ValueError:
+                raise ValueError(
+                    'value for {}: {} is not encoded in JSON'.format(
+                        key_name, val))
+            in_dict[key_name] = val
+    return in_dict

--- a/identifiers_client/identifiers_api.py
+++ b/identifiers_client/identifiers_api.py
@@ -1,5 +1,3 @@
-import json
-
 from globus_sdk import (AccessTokenAuthorizer, ClientCredentialsAuthorizer,
                         RefreshTokenAuthorizer, NativeAppAuthClient)
 from globus_sdk.base import BaseClient, safe_stringify
@@ -73,20 +71,6 @@ def _split_dict(in_dict, key_names):
     return in_dict, new_dict
 
 
-def _json_parse_args(in_dict, key_names):
-    for key_name in key_names:
-        val = in_dict.pop(key_name, None)
-        if val is not None:
-            try:
-                val = json.loads(val)
-            except ValueError:
-                raise ValueError(
-                    'value for {}: {} is not encoded in JSON'.format(
-                        key_name, val))
-            in_dict[key_name] = val
-    return in_dict
-
-
 class IdentifierClient(BaseClient):
     allowed_authorizer_types = (AccessTokenAuthorizer, RefreshTokenAuthorizer,
                                 ClientCredentialsAuthorizer)
@@ -116,7 +100,6 @@ class IdentifierClient(BaseClient):
                       "minting identfiers in JSON format
 
         """
-        kwargs = _json_parse_args(kwargs, _namespace_json_props)
         kwargs, body = _split_dict(kwargs, _namespace_properties)
         self.logger.info("IdentifierClient.create_namespace({}, ...)".format(
             body.get('display_name')))
@@ -147,7 +130,6 @@ class IdentifierClient(BaseClient):
           identfiers in JSON format
 
         """
-        kwargs = _json_parse_args(kwargs, _namespace_json_props)
         kwargs, body = _split_dict(kwargs, _namespace_properties)
         self.logger.info(
             "IdentifierClient.update_namespace({}, ...)".format(namespace_id))
@@ -202,7 +184,6 @@ class IdentifierClient(BaseClient):
           Additional metadata associated with the identifier
 
         """
-        kwargs = _json_parse_args(kwargs, _identifier_json_props)
         kwargs, body = _split_dict(kwargs, _identifier_properties)
         self.logger.info('IdentifierClient.create_identifier({}, ...)'.format(
             body.get('namespace_id')))
@@ -244,7 +225,6 @@ class IdentifierClient(BaseClient):
           Additional metadata associated with the identifier
 
         """
-        kwargs = _json_parse_args(kwargs, _identifier_json_props)
         kwargs, body = _split_dict(kwargs, _identifier_properties)
         self.logger.info('IdentifierClient.update_identifier({}, ...)'.format(
             body.get('identifier_id')))

--- a/identifiers_client/main.py
+++ b/identifiers_client/main.py
@@ -5,13 +5,14 @@ import logging
 
 from identifiers_client.local_server import is_remote_session
 from identifiers_client.identifiers_api import (
-    identifiers_client, IdentifierClientError, IdentifierNotLoggedIn)
+    identifiers_client, IdentifierClientError, IdentifierNotLoggedIn,
+    _identifier_json_props, _namespace_json_props)
 from identifiers_client.config import config
 from identifiers_client.login import (
     LOGGED_IN_RESPONSE, LOGGED_OUT_RESPONSE, check_logged_in,
     do_link_login_flow, do_local_server_login_flow, revoke_tokens)
 from identifiers_client.helpers import (subcommand, argument,
-                                        clear_internal_args)
+                                        clear_internal_args, json_parse_args)
 from argparse import ArgumentParser
 
 log = logging.getLogger(__name__)
@@ -142,7 +143,8 @@ def namespace_create(args):
     # This means all members will be admins.
     if 'creators' not in args:
         args['creators'] = args['admins']
-    return client.create_namespace(**args)
+    kwargs = json_parse_args(args, _namespace_json_props)
+    return client.create_namespace(**kwargs)
 
 
 @subcommand([
@@ -185,8 +187,8 @@ def namespace_update(args):
     if 'creators' not in args:
         args['creators'] = args['admins']
     namespace_id = args.pop('namespace_id')
-
-    return client.update_namespace(namespace_id, **args)
+    kwargs = json_parse_args(args, _namespace_json_props)
+    return client.update_namespace(namespace_id, **kwargs)
 
 
 @subcommand([
@@ -252,7 +254,8 @@ def identifier_create(args):
     """
     client = identifiers_client(config)
     args = clear_internal_args(vars(args))
-    return client.create_identifier(**args)
+    kwargs = json_parse_args(args, _identifier_json_props)
+    return client.create_identifier(**kwargs)
 
 
 @subcommand([
@@ -281,8 +284,8 @@ def identifier_update(args):
     client = identifiers_client(config)
     identifier_id = args.identifier
     args = clear_internal_args(vars(args))
-
-    return client.update_identifier(identifier_id, **args)
+    kwargs = json_parse_args(args, _identifier_json_props)
+    return client.update_identifier(identifier_id, **kwargs)
 
 
 @subcommand([


### PR DESCRIPTION
Changes proposed in #2. When calling into the api, it's now possible to do: 

```
from identifiers_client import config
from identifiers_client import identifiers_api
ic = identifiers_api.identifiers_client(config)

ic.create_identifier(visible_to=['public'], namespace='<namespace>')
ic.update_identifier(<identifier>, location=['foo.example.com'])
```
This changes also preserve the way CLI args are specified:
```
$ globus-identifiers-client identifier-create --namespace <namespace> --visible-to '["public"]'
```
