### PR TITLE
Add __init__ to IdentifierClient

### DIFF
--- a/identifiers_client/identifiers_api.py
+++ b/identifiers_client/identifiers_api.py
@@ -77,7 +77,7 @@ class IdentifierClient(BaseClient):
     error_class = IdentifierClientError
 
     def __init__(self, authorizer=None, **kwargs):
-        BaseClient.__init__(
+        super().__init__(
             self, "identifier", base_url="https://identifiers.globus.org/",
             authorizer=authorizer, **kwargs
         )

--- a/identifiers_client/identifiers_api.py
+++ b/identifiers_client/identifiers_api.py
@@ -41,7 +41,6 @@ def identifiers_client(config, **kwargs):
     )
 
     return IdentifierClient(
-        "identifier",
         base_url=base_url,
         app_name=app_name,
         authorizer=authorizer,
@@ -76,6 +75,12 @@ class IdentifierClient(BaseClient):
                                 ClientCredentialsAuthorizer)
 
     error_class = IdentifierClientError
+
+    def __init__(self, authorizer=None, **kwargs):
+        BaseClient.__init__(
+            self, "identifier", base_url="https://identifiers.globus.org/",
+            authorizer=authorizer, **kwargs
+        )
 
     def create_namespace(self, **kwargs):
         """


### PR DESCRIPTION
This PR adds an `__init__` to `IdentifierClient` to add the service name (`"identifier"`) and base url (`"https://identifiers.globus.org"`) to the `BaseClient.__init__` call, because those are static values for the Identifiers service, and to standardize the `IdentifierClient.__init__` to match the Globus SDK style.

This style of `__init__` can be seen in other Globus clients, such as [TransferClient](https://github.com/globus/globus-sdk-python/blob/master/globus_sdk/transfer/client.py#L132), [SearchClient](https://github.com/globus/globus-sdk-python/blob/master/globus_sdk/search/client.py#L57), and the unofficial [NexusClient](https://github.com/sirosen/globus-nexus-client/blob/master/globus_nexus_client/client.py#L33). Standardizing how clients are initialized makes using different clients easier and more intuitive, and (selfishly) will make the `IdentifierClient` easier to use for the MDF.

There are currently no automated tests in this repo but manual testing has not revealed any issues.