### PR TITLE
Remove possible doubly specific base_url kwarg

### DIFF
--- a/identifiers_client/identifiers_api.py
+++ b/identifiers_client/identifiers_api.py
@@ -76,9 +76,10 @@ class IdentifierClient(BaseClient):
 
     error_class = IdentifierClientError
 
-    def __init__(self, authorizer=None, **kwargs):
+    def __init__(self, authorizer=None,
+                 base_url="https://identifiers.globus.org/", **kwargs):
         super().__init__(
-            self, "identifier", base_url="https://identifiers.globus.org/",
+            self, "identifier", base_url=base_url,
             authorizer=authorizer, **kwargs
         )
 


### PR DESCRIPTION
It was possible that the base_url kwarg would be doubly passed in the
call to super on the IdentifierClient if it existed in the input
`kwargs` and was then added explicitly in the call to the super class.